### PR TITLE
Allow layout throuh url flag

### DIFF
--- a/frontend/webEditor/src/startUpAgent/LoadDefaultDiagram.ts
+++ b/frontend/webEditor/src/startUpAgent/LoadDefaultDiagram.ts
@@ -3,6 +3,8 @@ import { IStartUpAgent } from "./StartUpAgent";
 import { LoadDefaultDiagramAction } from "../serialize/loadDefaultDiagram";
 import { inject } from "inversify";
 import { LoadFromUrlAction } from "../serialize/LoadUrl";
+import { LayoutModelAction } from "../layout/command";
+import { LayoutMethod } from "../layout/layoutMethod";
 
 export class LoadDefaultDiagramStartUpAgent implements IStartUpAgent {
     constructor(@inject(TYPES.IActionDispatcher) private actionDispatcher: ActionDispatcher) {}
@@ -10,10 +12,15 @@ export class LoadDefaultDiagramStartUpAgent implements IStartUpAgent {
     run(): void {
         const urlParams = new URLSearchParams(window.location.search);
         const fileUrlParameter = urlParams.get("file");
-        this.actionDispatcher.dispatch(
+        const doLayout = urlParams.get("layout") === "true";
+        const actions = [
             fileUrlParameter != undefined
                 ? LoadFromUrlAction.create(fileUrlParameter)
                 : LoadDefaultDiagramAction.create(),
-        );
+        ];
+        if (doLayout) {
+            actions.push(LayoutModelAction.create(LayoutMethod.LINES));
+        }
+        this.actionDispatcher.dispatchAll(actions);
     }
 }


### PR DESCRIPTION
Allows layouting when setting a flag in the url with the `layout=true` flag

E.g. `https://editor.dataflowanalysis.org/?file=https://raw.githubusercontent.com/DataFlowAnalysis/DataFlowAnalysis/refs/heads/main/bundles/org.dataflowanalysis.examplemodels/scenarios/dfd/DocProc/DocProc.json&layout=true`