### PR TITLE
Fix second hover of node not working

### DIFF
--- a/frontend/webEditor/src/diagram/nodes/annotation.ts
+++ b/frontend/webEditor/src/diagram/nodes/annotation.ts
@@ -31,6 +31,7 @@ export class DfdNodeAnnotationUIMouseListener extends MouseListener {
                 clearTimeout(this.stillTimeout);
                 this.stillTimeout = undefined;
             }
+            this.lastTarget = undefined;
             return this.hidePopup();
         }
         this.lastPosition = { x: event.clientX, y: event.clientY };


### PR DESCRIPTION
When hovering a node for the second time, without hovering over another one in between the annotation did not show.