### PR TITLE
Allow entering a name for a dfd

### DIFF
--- a/frontend/webEditor/src/serialize/saveDfdAndDdFile.ts
+++ b/frontend/webEditor/src/serialize/saveDfdAndDdFile.ts
@@ -35,7 +35,7 @@ export class SaveDfdAndDdFileCommand extends SaveFileCommand {
     async getFiles(context: CommandExecutionContext): Promise<FileData<string>[]> {
         const savedDiagram = this.createSavedDiagram(context);
 
-        const newName = prompt("Enter new Name");
+        const newName = prompt("Enter Filename (Leave empty to use current file name)");
 
         const response = await this.dfdWebSocket.sendMessage(
             "Json2DFD:" + JSON.stringify(savedDiagram),

--- a/frontend/webEditor/src/serialize/saveDfdAndDdFile.ts
+++ b/frontend/webEditor/src/serialize/saveDfdAndDdFile.ts
@@ -35,7 +35,12 @@ export class SaveDfdAndDdFileCommand extends SaveFileCommand {
     async getFiles(context: CommandExecutionContext): Promise<FileData<string>[]> {
         const savedDiagram = this.createSavedDiagram(context);
 
-        const response = await this.dfdWebSocket.sendMessage("Json2DFD:" + JSON.stringify(savedDiagram));
+        const newName = prompt("Enter new Name");
+
+        const response = await this.dfdWebSocket.sendMessage(
+            "Json2DFD:" + JSON.stringify(savedDiagram),
+            newName || undefined,
+        );
         const nameEndIndex = response.indexOf(":");
         const name = response.substring(0, nameEndIndex);
         const endIndex =

--- a/frontend/webEditor/src/webSocket/webSocket.ts
+++ b/frontend/webEditor/src/webSocket/webSocket.ts
@@ -80,7 +80,7 @@ export class DfdWebSocket {
         };
     }
 
-    public sendMessage(message: string): Promise<string> {
+    public sendMessage(message: string, overwriteName?: string): Promise<string> {
         const result = new Promise<string>((resolve, reject) => {
             this.lastRequest.resolve = resolve;
             this.lastRequest.reject = reject;
@@ -90,7 +90,7 @@ export class DfdWebSocket {
             return result;
         }
 
-        this.webSocket.send(this.webSocketId + ":" + this.fileName.getName() + ":" + message);
+        this.webSocket.send(this.webSocketId + ":" + (overwriteName ?? this.fileName.getName()) + ":" + message);
         return result;
     }
 }


### PR DESCRIPTION
closes https://github.com/DataFlowAnalysis/DataFlowAnalysis/issues/286

opens a prompt when usign the save as DFD and DD option to enter a name. when leaving the name field empty, it uses the current name